### PR TITLE
[Feat] Next.js API Routes와 Faker.js를 활용한 목데이터 API 구현

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,8 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'export', // Outputs a Single-Page Application (SPA).
-  distDir: './dist', // Changes the build output directory to `./dist/`.
-  // basePath: process.env.NEXT_PUBLIC_BASE_PATH,
+  distDir: './dist',
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "vaul": "^0.9.2"
       },
       "devDependencies": {
+        "@faker-js/faker": "^9.6.0",
         "@types/node": "^20.14.2",
         "@types/react": "^18.2.66",
         "@types/react-dom": "^18.2.22",
@@ -144,6 +145,22 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.6.0.tgz",
+      "integrity": "sha512-3vm4by+B5lvsFPSyep3ELWmZfE3kicDtmemVpuwl1yH7tqtnHdsA6hG8fbXedMVdkzgtvzWoRgjSB4Q+FHnZiw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@floating-ui/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "axios": "^1.7.7",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "cookie": "^1.0.2",
         "embla-carousel-autoplay": "^8.3.0",
         "embla-carousel-react": "^8.3.0",
         "lucide-react": "^0.390.0",
@@ -2568,6 +2569,14 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.7.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "cookie": "^1.0.2",
     "embla-carousel-autoplay": "^8.3.0",
     "embla-carousel-react": "^8.3.0",
     "lucide-react": "^0.390.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "vaul": "^0.9.2"
   },
   "devDependencies": {
+    "@faker-js/faker": "^9.6.0",
     "@types/node": "^20.14.2",
     "@types/react": "^18.2.66",
     "@types/react-dom": "^18.2.22",

--- a/src/components/news/NewsComment.jsx
+++ b/src/components/news/NewsComment.jsx
@@ -1,14 +1,14 @@
-import { useState } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useToaster } from "@/contexts/ToasterProvider";
-import { formatDate } from "@/lib/utils";
-import axios from "@/lib/axios";
-import send from "@/assets/send.svg";
-import deleteIcon from "@/assets/delete.svg";
-import { SpinnerIcon } from "@/components/ui/custom/Loading";
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useToaster } from '@/contexts/ToasterProvider';
+import { formatDate } from '@/lib/utils';
+import axios from '@/lib/axios';
+import send from '@/assets/send.svg';
+import deleteIcon from '@/assets/delete.svg';
+import { SpinnerIcon } from '@/components/ui/custom/Loading';
 
 export default function NewsComment({ commentList, articleId }) {
-  const [comment, setComment] = useState("");
+  const [comment, setComment] = useState('');
   const queryClient = useQueryClient();
   const toast = useToaster();
 
@@ -18,12 +18,12 @@ export default function NewsComment({ commentList, articleId }) {
         comment: data,
       }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["article", articleId] });
-      toast("info", "댓글이 등록되었습니다.");
+      queryClient.invalidateQueries({ queryKey: ['article', articleId] });
+      toast('info', '댓글이 등록되었습니다.');
     },
     onError: (error) => {
-      console.error("Error:", error);
-      toast("error", "네트워크 오류가 발생했습니다.");
+      console.error('Error:', error);
+      toast('error', '네트워크 오류가 발생했습니다.');
     },
   });
 
@@ -31,19 +31,19 @@ export default function NewsComment({ commentList, articleId }) {
     mutationFn: (commentId) =>
       axios.delete(`/articles/${articleId}/comments/${commentId}`),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["article", articleId] });
-      toast("info", "댓글을 삭제했습니다.");
+      queryClient.invalidateQueries({ queryKey: ['article', articleId] });
+      toast('info', '댓글을 삭제했습니다.');
     },
     onError: (error) => {
-      console.error("Error:", error);
-      toast("error", "네트워크 오류가 발생했습니다.");
+      console.error('Error:', error);
+      toast('error', '네트워크 오류가 발생했습니다.');
     },
   });
 
   const handleSendClick = () => {
     if (!comment.trim()) return;
     addCommentMutation.mutate(comment);
-    setComment("");
+    setComment('');
   };
 
   const handleSubmit = (e) => {
@@ -77,7 +77,7 @@ export default function NewsComment({ commentList, articleId }) {
           {addCommentMutation.isPending ? (
             <SpinnerIcon />
           ) : (
-            <img className="w-6" src={send} alt="send" />
+            <img className="w-6" src={send.src} alt="send" />
           )}
         </button>
       </form>
@@ -103,7 +103,11 @@ export default function NewsComment({ commentList, articleId }) {
                     deleteCommentMutation.mutate(comment.commentId)
                   }
                 >
-                  <img className="w-2.5 h-full" src={deleteIcon} alt="삭제" />
+                  <img
+                    className="w-2.5 h-full"
+                    src={deleteIcon.src}
+                    alt="삭제"
+                  />
                 </button>
               )}
             </div>

--- a/src/components/news/NewsDetailContent.jsx
+++ b/src/components/news/NewsDetailContent.jsx
@@ -1,51 +1,51 @@
-import { useState, useEffect } from "react";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import NewsComment from "./NewsComment";
-import ai_default from "@/assets/ai_default.svg";
-import ai_white from "@/assets/ai_white.svg";
-import comment_default from "@/assets/comment_default.svg";
-import comment_white from "@/assets/comment_white.svg";
-import like_default from "@/assets/like_default.svg";
-import like_green from "@/assets/like_green.svg";
-import axios from "@/lib/axios";
-import { useToaster } from "@/contexts/ToasterProvider";
+import { useState, useEffect } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import NewsComment from './NewsComment';
+import ai_default from '@/assets/ai_default.svg';
+import ai_white from '@/assets/ai_white.svg';
+import comment_default from '@/assets/comment_default.svg';
+import comment_white from '@/assets/comment_white.svg';
+import like_default from '@/assets/like_default.svg';
+import like_green from '@/assets/like_green.svg';
+import axios from '@/lib/axios';
+import { useToaster } from '@/contexts/ToasterProvider';
 
 const NewsDetailContent = ({ isPending, article, articleId }) => {
-  const [contentType, setContentType] = useState("ai");
+  const [contentType, setContentType] = useState('ai');
   const queryClient = useQueryClient();
   const toast = useToaster();
 
   useEffect(() => {
-    setContentType("ai");
+    setContentType('ai');
   }, [articleId]);
 
   const addLikeMutation = useMutation({
     mutationFn: (articleId) => axios.post(`/articles/${articleId}/likes`),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["article", articleId] });
-      toast("info", "좋아요를 눌렀습니다.");
+      queryClient.invalidateQueries({ queryKey: ['article', articleId] });
+      toast('info', '좋아요를 눌렀습니다.');
       axios.post(`/articles/${articleId}/rate`, {
         preference: 2,
       });
     },
     onError: (error) => {
-      console.error("Error:", error);
-      toast("error", "네트워크 오류가 발생했습니다.");
+      console.error('Error:', error);
+      toast('error', '네트워크 오류가 발생했습니다.');
     },
   });
 
   const deleteLikeMutation = useMutation({
     mutationFn: (articleId) => axios.delete(`/articles/${articleId}/likes`),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["article", articleId] });
-      toast("info", "좋아요가 취소되었습니다");
+      queryClient.invalidateQueries({ queryKey: ['article', articleId] });
+      toast('info', '좋아요가 취소되었습니다');
       axios.post(`/articles/${articleId}/rate`, {
         preference: 0,
       });
     },
     onError: (error) => {
-      console.error("Error:", error);
-      toast("error", "네트워크 오류가 발생했습니다.");
+      console.error('Error:', error);
+      toast('error', '네트워크 오류가 발생했습니다.');
     },
   });
 
@@ -55,13 +55,13 @@ const NewsDetailContent = ({ isPending, article, articleId }) => {
   };
 
   const handleContentChange = (type) => {
-    if (type === contentType) setContentType("");
+    if (type === contentType) setContentType('');
     else setContentType(type);
   };
 
   const setButtonClass = (type) => {
     return `flex gap-2 items-center font-bold py-2 px-3 rounded-full border-[1px] ${
-      type === contentType ? "bg-my-green text-white" : "bg-white"
+      type === contentType ? 'bg-my-green text-white' : 'bg-white'
     }`;
   };
 
@@ -80,42 +80,48 @@ const NewsDetailContent = ({ isPending, article, articleId }) => {
       <div className="flex justify-between">
         <button
           onClick={() => {
-            handleContentChange("ai");
+            handleContentChange('ai');
           }}
-          className={setButtonClass("ai")}
+          className={setButtonClass('ai')}
         >
           <img
             className="w-5"
-            src={contentType === "ai" ? ai_white : ai_default}
+            src={contentType === 'ai' ? ai_white.src : ai_default.src}
           />
           AI 요약
         </button>
         <button
           onClick={() => {
-            handleContentChange("comment");
+            handleContentChange('comment');
           }}
-          className={setButtonClass("comment")}
+          className={setButtonClass('comment')}
         >
           <img
             className="w-5"
-            src={contentType === "comment" ? comment_white : comment_default}
+            src={
+              contentType === 'comment'
+                ? comment_white.src
+                : comment_default.src
+            }
           />
           댓글
         </button>
         <button onClick={toggleLike} className={setButtonClass()}>
           <img
             className="w-5"
-            src={article.likedArticle ?? false ? like_green : like_default}
+            src={
+              article.likedArticle ?? false ? like_green.src : like_default.src
+            }
           />
           {article.likeCount ?? 0}
         </button>
       </div>
       <div>
-        {contentType === "ai" ? (
+        {contentType === 'ai' ? (
           <div className="bg-white text-base text-black mt-4 p-4 rounded-lg border-[1px] border-my-green">
             {article.content}
           </div>
-        ) : contentType === "comment" ? (
+        ) : contentType === 'comment' ? (
           <NewsComment
             commentList={article.comment.reverse()}
             articleId={articleId}

--- a/src/components/user/BasicInformation.jsx
+++ b/src/components/user/BasicInformation.jsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
-import { Button } from "@/components/ui/shadcn/button";
-import { useUser } from "@/contexts/UserProvider";
-import { SpinnerIcon } from "@/components/ui/custom/Loading";
+import { useState } from 'react';
+import { Button } from '@/components/ui/shadcn/button';
+import { useUser } from '@/contexts/UserProvider';
+import { SpinnerIcon } from '@/components/ui/custom/Loading';
 
 const BasicInformation = ({ onNext, buttonText, buttonDisabled }) => {
   const { userProfile } = useUser();
@@ -10,29 +10,29 @@ const BasicInformation = ({ onNext, buttonText, buttonDisabled }) => {
     name: userProfile.name,
     email: userProfile.email,
     phone: userProfile.phone,
-    birth: userProfile.birth.replace(/-/g, "/"),
+    birth: userProfile.birth,
     gender: userProfile.gender,
   });
 
   const [errors, setErrors] = useState({
-    email: "",
-    phone: "",
+    email: '',
+    phone: '',
   });
 
   const validateField = (name, value) => {
     const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     const phonePattern = /^010-\d{4}-\d{4}$/;
 
-    let error = "";
+    let error = '';
 
     switch (name) {
-      case "email":
+      case 'email':
         if (!emailPattern.test(value))
-          error = "이메일 형식이 올바르지 않습니다.";
+          error = '이메일 형식이 올바르지 않습니다.';
         break;
-      case "phone":
+      case 'phone':
         if (!phonePattern.test(value))
-          error = "전화번호 형식이 올바르지 않습니다.";
+          error = '전화번호 형식이 올바르지 않습니다.';
         break;
       default:
         break;
@@ -46,7 +46,7 @@ const BasicInformation = ({ onNext, buttonText, buttonDisabled }) => {
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    const newValue = name === "phone" ? formatPhone(value) : value;
+    const newValue = name === 'phone' ? formatPhone(value) : value;
 
     setData((prev) => ({
       ...prev,
@@ -57,14 +57,14 @@ const BasicInformation = ({ onNext, buttonText, buttonDisabled }) => {
   };
 
   const formatPhone = (phone) => {
-    const numbers = phone.replace(/\D/g, "");
+    const numbers = phone.replace(/\D/g, '');
     const parts = [
       numbers.slice(0, 3),
       numbers.slice(3, 7),
       numbers.slice(7, 11),
     ].filter(Boolean);
 
-    return parts.join("-");
+    return parts.join('-');
   };
 
   const isFormComplete = () => {

--- a/src/components/user/DetailInformation.jsx
+++ b/src/components/user/DetailInformation.jsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
-import { Button } from "@/components/ui/shadcn/button";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/shadcn/radio-group";
-import { useUser } from "@/contexts/UserProvider";
+import { useState } from 'react';
+import { Button } from '@/components/ui/shadcn/button';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/shadcn/radio-group';
+import { useUser } from '@/contexts/UserProvider';
 
 const DetailInformation = ({ onNext, buttonText }) => {
   const { userProfile } = useUser();
@@ -17,7 +17,7 @@ const DetailInformation = ({ onNext, buttonText }) => {
     }));
   };
 
-  const today = new Date().toISOString().split("T")[0];
+  const today = new Date().toISOString().split('T')[0];
   return (
     <>
       <div className="border-2 border-border rounded-xl flex relative m-1 p-4">
@@ -26,7 +26,7 @@ const DetailInformation = ({ onNext, buttonText }) => {
           className="m-4"
           value={data.gender}
           onValueChange={(value) => {
-            handleChange("gender", value);
+            handleChange('gender', value);
           }}
         >
           <div className="flex items-center space-x-4 mb-4">
@@ -45,7 +45,7 @@ const DetailInformation = ({ onNext, buttonText }) => {
           type="date"
           name="birth"
           value={data.birth}
-          onChange={(e) => handleChange("birth", e.target.value)}
+          onChange={(e) => handleChange('birth', e.target.value)}
           min="1900-01-01"
           max={today}
         />
@@ -56,7 +56,7 @@ const DetailInformation = ({ onNext, buttonText }) => {
         onClick={() =>
           onNext({
             ...data,
-            birth: data.birth.replace(/-/g, "/"),
+            birth: data.birth,
           })
         }
         disabled={!(data.gender && data.birth)}

--- a/src/components/user/SignUpComplete.jsx
+++ b/src/components/user/SignUpComplete.jsx
@@ -20,20 +20,18 @@ const SignUpComplete = ({ formData }) => {
   }
 
   const onClickStart = async () => {
-    // setIsLoading(true);
-    // try {
-    //   await updateUserProfile.mutateAsync(formData.memberInfo);
-    //   await updateUserCategories.mutateAsync(formData.categories);
-    //   await updateUserPublishers.mutateAsync(formData.publishers);
+    setIsLoading(true);
+    try {
+      await updateUserProfile.mutateAsync(formData.memberInfo);
+      await updateUserCategories.mutateAsync(formData.categories);
+      await updateUserPublishers.mutateAsync(formData.publishers);
 
-    //   window.location.replace('/');
-    // } catch (error) {
-    //   console.error('Update failed:', error);
-    // } finally {
-    //   setIsLoading(false);
-    // }
-
-    window.location.replace('/');
+      window.location.replace('/');
+    } catch (error) {
+      console.error('Update failed:', error);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (

--- a/src/contexts/UserProvider.jsx
+++ b/src/contexts/UserProvider.jsx
@@ -26,18 +26,9 @@ export function UserProvider({ children }) {
 
   const { data: userProfile = {}, isLoading: isLoadingProfile } = useQuery({
     queryKey: ['userProfile'],
-    // queryFn: () => axios.get('/member/info'),
-    queryFn: () => ({
-      result: {
-        nickname: '',
-        email: '',
-        phone: '',
-        birth: '',
-        gender: '',
-      },
-    }),
+    queryFn: () => axios.get('/member/info'),
     select: ({ result }) => ({
-      name: result?.nickname ?? '',
+      name: result?.name ?? '',
       email: result?.email ?? '',
       phone: result?.phone ?? '',
       birth: result?.birth?.split('T')[0] ?? '',
@@ -49,14 +40,14 @@ export function UserProvider({ children }) {
   const { data: categories = [], isLoading: isLoadingCategories } = useQuery({
     queryKey: ['categories'],
     queryFn: () => axios.get('/member/categories'),
-    select: (data) => data.result.preferredCategories,
+    select: (data) => data.result,
     enabled: isEnabled,
   });
 
   const { data: publishers = [], isLoading: isLoadingPublishers } = useQuery({
     queryKey: ['publishers'],
     queryFn: () => axios.get('/member/press'),
-    select: (data) => data.result.preferredPress,
+    select: (data) => data.result,
     enabled: isEnabled,
   });
 
@@ -68,20 +59,14 @@ export function UserProvider({ children }) {
   });
 
   const updateUserCategories = useMutation({
-    mutationFn: (data) =>
-      axios.put('/member/categories', {
-        preferredCategories: data,
-      }),
+    mutationFn: (data) => axios.put('/member/categories', data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['categories'] });
     },
   });
 
   const updateUserPublishers = useMutation({
-    mutationFn: (data) =>
-      axios.put('/member/press', {
-        preferredPress: data,
-      }),
+    mutationFn: (data) => axios.put('/member/press', data),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['publishers'] });
     },

--- a/src/contexts/UserProvider.jsx
+++ b/src/contexts/UserProvider.jsx
@@ -31,7 +31,7 @@ export function UserProvider({ children }) {
       name: result?.name ?? '',
       email: result?.email ?? '',
       phone: result?.phone ?? '',
-      birth: result?.birth?.split('T')[0] ?? '',
+      birth: result?.birth ?? '',
       gender: result?.gender ?? '',
     }),
     enabled: isEnabled,

--- a/src/hooks/useNewsQuery.jsx
+++ b/src/hooks/useNewsQuery.jsx
@@ -1,5 +1,5 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
-import axios from "@/lib/axios";
+import { useInfiniteQuery } from '@tanstack/react-query';
+import axios from '@/lib/axios';
 
 const PAGE_SIZE = 10;
 
@@ -13,7 +13,7 @@ function useNewsQuery(category, search) {
       isFetchingNextPage,
       hasNextPage,
     } = useInfiniteQuery({
-      queryKey: ["searchArticles", search],
+      queryKey: ['searchArticles', search],
       queryFn: ({ pageParam }) => {
         if (pageParam === -1)
           return axios.get(
@@ -47,14 +47,15 @@ function useNewsQuery(category, search) {
     isFetchingNextPage,
     hasNextPage,
   } = useInfiniteQuery({
-    queryKey: ["articles", category],
+    queryKey: ['articles', category],
     queryFn: ({ pageParam }) =>
-      axios.get(
-        `/articles/recommend?page=${pageParam}&category=${category}&pageSize=${PAGE_SIZE}`
-      ),
-    initialPageParam: 1,
-    getNextPageParam: (lastPage, allPages, lastPageParam, allPageParams) =>
-      lastPage.hasMore ? lastPageParam + 1 : null,
+      axios.get(`/articles?page=${pageParam}&pageSize=${PAGE_SIZE}`),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage, allPages, lastPageParam, allPageParams) => {
+      console.log({ lastPage, allPages, lastPageParam, allPageParams });
+
+      return lastPage.hasMore ? lastPageParam + 1 : null;
+    },
   });
 
   return {

--- a/src/hooks/useNewsQuery.jsx
+++ b/src/hooks/useNewsQuery.jsx
@@ -14,20 +14,13 @@ function useNewsQuery(category, search) {
       hasNextPage,
     } = useInfiniteQuery({
       queryKey: ['searchArticles', search],
-      queryFn: ({ pageParam }) => {
-        if (pageParam === -1)
-          return axios.get(
-            `/articles/search?keyword=${search}&size=${PAGE_SIZE}`
-          );
-        return axios.get(
-          `/articles/search?keyword=${search}&size=${PAGE_SIZE}&articleCursor=${pageParam}`
-        );
-      },
-      initialPageParam: -1,
-      getNextPageParam: (lastPage) =>
-        lastPage?.result.length < PAGE_SIZE
-          ? null
-          : lastPage.result[PAGE_SIZE - 1].articleId,
+      queryFn: ({ pageParam }) =>
+        axios.get(
+          `/articles/search?keyword=${search}&page=${pageParam}&pageSize=${PAGE_SIZE}`
+        ),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, allPages, lastPageParam) =>
+        lastPage.hasMore ? lastPageParam + 1 : null,
     });
 
     return {
@@ -51,11 +44,8 @@ function useNewsQuery(category, search) {
     queryFn: ({ pageParam }) =>
       axios.get(`/articles?page=${pageParam}&pageSize=${PAGE_SIZE}`),
     initialPageParam: 0,
-    getNextPageParam: (lastPage, allPages, lastPageParam, allPageParams) => {
-      console.log({ lastPage, allPages, lastPageParam, allPageParams });
-
-      return lastPage.hasMore ? lastPageParam + 1 : null;
-    },
+    getNextPageParam: (lastPage, allPages, lastPageParam) =>
+      lastPage.hasMore ? lastPageParam + 1 : null,
   });
 
   return {

--- a/src/pages/api/articles/[id].js
+++ b/src/pages/api/articles/[id].js
@@ -1,0 +1,30 @@
+import { faker } from '@faker-js/faker';
+
+export default function handler(req, res) {
+  if (req.method === 'GET') {
+    const { id } = req.query;
+
+    return res.status(200).json({
+      message: '요청에 성공했습니다.',
+      result: {
+        title: '기사 등록.',
+        content: faker.lorem.sentences(),
+        articleSource: `https://www.example.com/${id}`,
+        comment: [
+          {
+            commentId: 1,
+            content: '텍스트',
+            nickName: 'nnijgnus',
+            likeCount: 0,
+            createdDate: '2024-10-26T04:48:40.221635',
+            isMyComment: true,
+          },
+        ],
+        likeCount: faker.number.int({ max: 999 }),
+        likedArticle: false,
+      },
+    });
+  }
+
+  return res.status(405).json({ message: '잘못된 요청입니다.' });
+}

--- a/src/pages/api/articles/headLine.js
+++ b/src/pages/api/articles/headLine.js
@@ -1,16 +1,14 @@
 import { faker } from '@faker-js/faker';
 
+const HEADLINE_SIZE = 5;
+
 export default function handler(req, res) {
   if (req.method === 'GET') {
-    const { page, pageSize } = req.query;
-
-    const paredSize = pageSize ? parseInt(pageSize) : 5;
-    const parsedPage = page ? page : 0;
-
-    const articles = Array.from({ length: paredSize }).map((_, index) => ({
-      articleId: parseInt(parsedPage + index),
-      title: `기사 ${parseInt(parsedPage + index)}`,
+    const articles = Array.from({ length: HEADLINE_SIZE }).map((_, index) => ({
+      articleId: `H${index}`,
+      title: `기사 H${index}`,
       press: 'JOONGANG',
+      headLine: faker.lorem.sentence(),
       thumbnail: faker.image.url(),
       publishDate: faker.date.recent({ days: 7 }),
     }));
@@ -18,7 +16,6 @@ export default function handler(req, res) {
     return res.status(200).json({
       message: '요청에 성공했습니다.',
       result: articles,
-      hasMore: parsedPage < 10,
     });
   }
 

--- a/src/pages/api/articles/index.js
+++ b/src/pages/api/articles/index.js
@@ -1,0 +1,26 @@
+import { faker } from '@faker-js/faker';
+
+export default function handler(req, res) {
+  if (req.method === 'GET') {
+    const { page, pageSize } = req.query;
+
+    const paredSize = pageSize ? parseInt(pageSize) : 10;
+    const parsedPage = page ? page : 0;
+
+    const articles = Array.from({ length: paredSize }).map((_, index) => ({
+      articleId: parseInt(parsedPage + index),
+      title: `기사 ${parseInt(parsedPage + index)}`,
+      press: 'JOONGANG',
+      thumbnail: faker.image.url(),
+      publishDate: faker.date.recent({ days: 7 }),
+    }));
+
+    return res.status(200).json({
+      message: '요청에 성공했습니다.',
+      result: articles,
+      hasMore: paredSize < 10,
+    });
+  }
+
+  return res.status(405).json({ message: '잘못된 요청입니다.' });
+}

--- a/src/pages/api/articles/index.js
+++ b/src/pages/api/articles/index.js
@@ -4,7 +4,7 @@ export default function handler(req, res) {
   if (req.method === 'GET') {
     const { page, pageSize } = req.query;
 
-    const paredSize = pageSize ? parseInt(pageSize) : 5;
+    const paredSize = pageSize ? parseInt(pageSize) : 10;
     const parsedPage = page ? page : 0;
 
     const articles = Array.from({ length: paredSize }).map((_, index) => ({

--- a/src/pages/api/articles/search.js
+++ b/src/pages/api/articles/search.js
@@ -2,14 +2,14 @@ import { faker } from '@faker-js/faker';
 
 export default function handler(req, res) {
   if (req.method === 'GET') {
-    const { page, pageSize } = req.query;
+    const { keyword, page, pageSize } = req.query;
 
     const paredSize = pageSize ? parseInt(pageSize) : 5;
     const parsedPage = page ? page : 0;
 
     const articles = Array.from({ length: paredSize }).map((_, index) => ({
       articleId: parseInt(parsedPage + index),
-      title: `기사 ${parseInt(parsedPage + index)}`,
+      title: `${keyword} 기사 ${parseInt(parsedPage + index)}`,
       press: 'JOONGANG',
       thumbnail: faker.image.url(),
       publishDate: faker.date.recent({ days: 7 }),

--- a/src/pages/api/member/categories.js
+++ b/src/pages/api/member/categories.js
@@ -1,0 +1,44 @@
+import { serialize } from 'cookie';
+
+export default function handler(req, res) {
+  if (req.method === 'PUT') {
+    const categories = JSON.stringify(req.body);
+
+    // 쿠키 설정
+    res.setHeader(
+      'Set-Cookie',
+      serialize('categories', categories, {
+        httpOnly: true,
+        sameSite: 'strict',
+        maxAge: 3600,
+        path: '/',
+      })
+    );
+
+    return res.status(200).json({ message: '카테고리 정보가 저장되었습니다.' });
+  }
+
+  if (req.method === 'GET') {
+    const cookies = req.headers.cookie || '';
+
+    // categories 쿠키 찾기
+    const categoryCookie = cookies
+      .split('; ')
+      .find((row) => row.startsWith('categories='));
+
+    if (!categoryCookie) {
+      return res.status(200).json({
+        message: '저장된 정보 없음',
+        result: [],
+      });
+    }
+
+    // 쿠키에서 정보 가져오기
+    const categories = JSON.parse(
+      decodeURIComponent(categoryCookie.split('=')[1])
+    );
+    return res.status(200).json({ result: categories });
+  }
+
+  return res.status(405).json({ message: '잘못된 요청입니다.' });
+}

--- a/src/pages/api/member/info.js
+++ b/src/pages/api/member/info.js
@@ -1,0 +1,48 @@
+import { serialize } from 'cookie';
+
+export default function handler(req, res) {
+  if (req.method === 'PUT') {
+    const { name, email, phone, birth, gender } = req.body;
+    const userInfo = JSON.stringify({ name, email, phone, birth, gender });
+
+    // 쿠키 설정
+    res.setHeader(
+      'Set-Cookie',
+      serialize('userInfo', userInfo, {
+        httpOnly: true,
+        sameSite: 'strict',
+        maxAge: 3600,
+        path: '/',
+      })
+    );
+
+    return res.status(200).json({ message: '유저 정보가 저장되었습니다.' });
+  }
+
+  if (req.method === 'GET') {
+    const cookies = req.headers.cookie || '';
+
+    // userInfo 쿠키 찾기
+    const userCookie = cookies
+      .split('; ')
+      .find((row) => row.startsWith('userInfo='));
+
+    if (!userCookie) {
+      return res.status(200).json({
+        message: '저장된 정보 없음',
+        result: {
+          name: '',
+          email: '',
+          phone: '',
+          birth: '',
+          gender: '',
+        },
+      });
+    }
+
+    // 쿠키에서 정보 가져오기
+    const userInfo = JSON.parse(decodeURIComponent(userCookie.split('=')[1]));
+    return res.status(200).json({ result: userInfo });
+  }
+  return res.status(405).json({ message: '잘못된 요청입니다.' });
+}

--- a/src/pages/api/member/press.js
+++ b/src/pages/api/member/press.js
@@ -1,0 +1,43 @@
+import { serialize } from 'cookie';
+
+export default function handler(req, res) {
+  if (req.method === 'PUT') {
+    const publishers = JSON.stringify(req.body);
+
+    // 쿠키 설정
+    res.setHeader(
+      'Set-Cookie',
+      serialize('publishers', publishers, {
+        httpOnly: true,
+        sameSite: 'strict',
+        maxAge: 3600,
+        path: '/',
+      })
+    );
+
+    return res.status(200).json({ message: '카테고리 정보가 저장되었습니다.' });
+  }
+
+  if (req.method === 'GET') {
+    const cookies = req.headers.cookie || '';
+
+    // publishers 쿠키 찾기
+    const publisherCookie = cookies
+      .split('; ')
+      .find((row) => row.startsWith('publishers='));
+
+    if (!publisherCookie) {
+      return res.status(200).json({
+        message: '저장된 정보 없음',
+        result: [],
+      });
+    }
+
+    // 쿠키에서 정보 가져오기
+    const publishers = JSON.parse(
+      decodeURIComponent(publisherCookie.split('=')[1])
+    );
+    return res.status(200).json({ result: publishers });
+  }
+  return res.status(405).json({ message: '잘못된 요청입니다.' });
+}

--- a/src/pages/user/[variant].jsx
+++ b/src/pages/user/[variant].jsx
@@ -22,18 +22,16 @@ const Setting = () => {
   };
 
   const handleNext = (data) => {
-    // variantConfig[router.query.variant].fetchFunction.mutate(data, {
-    //   onSuccess: () => {
-    //     toast('info', '저장되었습니다.');
-    //     router.push('/user');
-    //   },
-    //   onError: (error) => {
-    //     console.error('Error:', error);
-    //     toast('error', '저장 중 오류가 발생했습니다.');
-    //   },
-    // });
-    toast('info', '저장되었습니다.');
-    router.push('/user');
+    variantConfig[router.query.variant].fetchFunction.mutate(data, {
+      onSuccess: () => {
+        toast('info', '저장되었습니다.');
+        router.push('/user');
+      },
+      onError: (error) => {
+        console.error('Error:', error);
+        toast('error', '저장 중 오류가 발생했습니다.');
+      },
+    });
   };
 
   const renderComponent = () => {


### PR DESCRIPTION
## 🔗 연관된 이슈
- Close: #3 

## 📂 작업 내용
- 뉴스 관련 API 구현
  - `/api/articles` - 뉴스 목록 API
  - `/api/articles/[id]` - 뉴스 상세 API
  - `/api/articles/headLine` - 헤드라인 뉴스 API
  - `/api/articles/search` - 뉴스 검색 API
- 회원 정보 관련 API 구현
  - `/api/member/info` - 사용자 정보 관리 API
  - `/api/member/categories` - 카테고리 설정 API
  - `/api/member/press` - 언론사 설정 API
  - 사용자 정보, 선호 카테고리, 구독 언론사 정보를 쿠키로 유지

## 📑 참고 자료 & 스크린샷
- [faker 공식 문서](https://fakerjs.dev/)
- [Next.js - API Routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes)